### PR TITLE
Remove warning on free db

### DIFF
--- a/FillOutCardRwCards.php
+++ b/FillOutCardRwCards.php
@@ -218,5 +218,3 @@ class FillOutCardRwCards extends Frontend
 		}
 	}
 }
-
-?>

--- a/FillOutCardRwCards.php
+++ b/FillOutCardRwCards.php
@@ -107,7 +107,6 @@ class FillOutCardRwCards extends Frontend
 		$objTemplate->formId = 'rwcards_fillout_form';
 		$objTemplate->action = ampersand($this->Environment->request);
 		$objTemplate->nextPage = $this->nextPage;
-		$objTemplate->objPage = clone $objPage;
 
 		// Form fields
 		$arrFields = array

--- a/ListRwCards.php
+++ b/ListRwCards.php
@@ -123,7 +123,6 @@ class ListRwCards extends Frontend
 		$objTemplate->reWritetoSender = (\Input::get('view') == "reWritetoSender") ? 1 : 0;
 		$objTemplate->sessionId = $this->sessionId;
 		$objTemplate->nextPage = $this->nextPage;
-		$objTemplate->objPage = clone $objPage;
 		++$count;
 	}
 }

--- a/ListRwCards.php
+++ b/ListRwCards.php
@@ -126,5 +126,3 @@ class ListRwCards extends Frontend
 		++$count;
 	}
 }
-
-?>

--- a/OneCategoryRwCards.php
+++ b/OneCategoryRwCards.php
@@ -117,7 +117,6 @@ class OneCategoryRwCards extends \Frontend
 		}
 		
 		$objTemplate->nextPage = $this->nextPage;
-		$objTemplate->objPage = clone $objPage;
 //var_dump($objTemplate->data);
 	}
 

--- a/OneCategoryRwCards.php
+++ b/OneCategoryRwCards.php
@@ -144,5 +144,3 @@ class OneCategoryRwCards extends \Frontend
 		return $resCats->execute()->fetchAllAssoc();
 	}
 }
-
-?>

--- a/PreviewCardRwCards.php
+++ b/PreviewCardRwCards.php
@@ -89,7 +89,6 @@ class PreviewCardRwCards extends Frontend
 		$objTemplate->action = ampersand($this->Environment->request);
 		$objTemplate->card_id = $this->card_id;
 		$objTemplate->nextPage = $this->nextPage;
-		$objTemplate->objPage = clone $objPage;
 
 		// Form fields
 		$arrFields = array

--- a/PreviewCardRwCards.php
+++ b/PreviewCardRwCards.php
@@ -190,5 +190,3 @@ class PreviewCardRwCards extends Frontend
 		}
 	}
 }
-
-?>

--- a/SendCardRwCards.php
+++ b/SendCardRwCards.php
@@ -269,5 +269,3 @@ class SendCardRwCards extends Frontend {
 	}
 
 }
-
-?>

--- a/SendCardRwCards.php
+++ b/SendCardRwCards.php
@@ -103,7 +103,6 @@ class SendCardRwCards extends Frontend {
 		$objTemplate->sessionId = (\Input::get('view') == "rwcardsReWriteCard") ? \Input::get('sessionId') : null;
 		$objTemplate->alias = $alias;
 		$objTemplate->nextPage = $this->nextPage;
-		$objTemplate->objPage = clone $objPage;
 
 		if (\Input::get('view') == "rwcardsReWriteCard") {
 			// New Card or someone answers


### PR DESCRIPTION
Hi, habe diesen Beitrag: https://community.contao.org/de/showthread.php?29211-RWCards-und-Flash gelesen und unser Logfile war auch voll ;)

So wie ich ich das sehe, wird das geklonte Objekt nicht mehr am Templte benötigt, habe ich was übersehen?